### PR TITLE
Add ability to specify host parameter

### DIFF
--- a/lib/travis/become/app.rb
+++ b/lib/travis/become/app.rb
@@ -46,6 +46,10 @@ route :get, :post, '/:login' do
       end
     end
 
+    if params[:host]
+      @action = "https://#{params[:host]}"
+    end
+
     erb :become
   rescue ActiveRecord::RecordNotFound
     status 404


### PR DESCRIPTION
This lets you add a `host` query parameter to be forwarded to a particular `travis-web` host. For instance, [https://become.travis-ci.com/brandondean?host=bd-build-history-gap.test-deployments.travis-ci.com](https://become.travis-ci.com/brandondean?host=bd-build-history-gap.test-deployments.travis-ci.com) will let you become [the person from this thread](https://secure.helpscout.net/conversation/292830916/46179/?folderId=30788) to test out a possible bug fix of mine.

This is a naïve implementation. I will consult.