### PR TITLE
Use only user channel for pusher

### DIFF
--- a/lib/travis/become/model/user.rb
+++ b/lib/travis/become/model/user.rb
@@ -20,7 +20,7 @@ module Travis
           synced_at: format_date(synced_at),
           correct_scopes: correct_scopes?,
           created_at: format_date(created_at),
-          channels: ["user-#{id}"] + repository_ids.map { |id| "repo-#{id}" },
+          channels: ["user-#{id}"]
           token: tokens.first.try(:token).to_s,
         }
       end


### PR DESCRIPTION
We changed a way Pusher works and now we send all of the updates
concerning a logged in user via a user channel