### PR TITLE
Fix typo in user data hash

### DIFF
--- a/lib/travis/become/model/user.rb
+++ b/lib/travis/become/model/user.rb
@@ -20,8 +20,8 @@ module Travis
           synced_at: format_date(synced_at),
           correct_scopes: correct_scopes?,
           created_at: format_date(created_at),
-          channels: ["user-#{id}"]
-          token: tokens.first.try(:token).to_s,
+          channels: ["user-#{id}"],
+          token: tokens.first.try(:token).to_s
         }
       end
 


### PR DESCRIPTION
From the logs:

```
2017-08-31T07:40:52.961354+00:00 Starting process with command `bundle exec ./script/server`
2017-08-31T07:40:57.116488+00:00 Process exited with status 1
2017-08-31T07:40:56.894009+00:00 bundler: failed to load command: rackup (/app/vendor/bundle/ruby/2.3.0/bin/rackup)
2017-08-31T07:40:56.894242+00:00 SyntaxError: /app/lib/travis/become/model/user.rb:24: syntax error, unexpected tIDENTIFIER, expecting '}'
2017-08-31T07:40:56.894244+00:00           token: tokens.first.try(:token).to_s,
2017-08-31T07:40:56.894245+00:00                ^
2017-08-31T07:40:56.894245+00:00 /app/lib/travis/become/model/user.rb:25: syntax error, unexpected '}', expecting '='
2017-08-31T07:40:56.894246+00:00 /app/lib/travis/become/model/user.rb:48: syntax error, unexpected end-of-input, expecting keyword_end
```