### PR TITLE
Change Redis.connect to Redis.new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.3.4'
 
 gem 'travis-sso', git: 'https://github.com/travis-ci/travis-sso'
-gem 'travis-config', '~> 1.0.0'
+gem 'travis-config', git: 'https://github.com/travis-ci/travis-config'
 
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/travis-ci/travis-config
+  revision: 778468a12f833eab9c7c3cf61ebf60e294eb4180
+  specs:
+    travis-config (1.1.2)
+      hashr (~> 2.0)
+
+GIT
   remote: https://github.com/travis-ci/travis-sso
   revision: 8b41951a7a1905978ae3bb6ecaffa88f2f22d3d7
   specs:
@@ -70,8 +77,6 @@ GEM
       tilt (>= 1.3, < 3)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    travis-config (1.0.13)
-      hashr (~> 2.0.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     yubikey (1.4.1)
@@ -89,11 +94,11 @@ DEPENDENCIES
   sentry-raven
   sinatra
   sinatra-contrib
-  travis-config (~> 1.0.0)
+  travis-config!
   travis-sso!
 
 RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/travis/become/access_token.rb
+++ b/lib/travis/become/access_token.rb
@@ -46,7 +46,7 @@ module Travis
       private
 
         def redis
-          Thread.current[:redis] ||= ::Redis.connect(url: Travis::Become.config.redis.url)
+          Thread.current[:redis] ||= ::Redis.new(url: Travis::Become.config.redis.url)
         end
 
         def key(token)


### PR DESCRIPTION
The version bump created issues since the api in redis-rb changed:

```
2018-06-01 12:23:32 - NoMethodError - undefined method `connect' for Redis:Class:
```

fixes 7523500d8b229b27da83749e58b2b5ed61768310