### PR TITLE
Bump gem versions for security patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.4'
 gem 'travis-sso', git: 'https://github.com/travis-ci/travis-sso'
 gem 'travis-config', git: 'https://github.com/travis-ci/travis-config'
 
-gem 'sinatra', '>= 2.0.2'
+gem 'sinatra', ">= 2.0.2"
 gem 'sinatra-contrib'
 
 gem 'sentry-raven'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.4'
 gem 'travis-sso', git: 'https://github.com/travis-ci/travis-sso'
 gem 'travis-config', git: 'https://github.com/travis-ci/travis-config'
 
-gem 'sinatra'
+gem 'sinatra', '>= 2.0.2'
 gem 'sinatra-contrib'
 
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/travis-ci/travis-config
-  revision: 778468a12f833eab9c7c3cf61ebf60e294eb4180
+  revision: 0c5b76989c5da2b842e8ef02eb3082df09abe6c2
   specs:
     travis-config (1.1.2)
       hashr (~> 2.0)
 
 GIT
   remote: https://github.com/travis-ci/travis-sso
-  revision: 8b41951a7a1905978ae3bb6ecaffa88f2f22d3d7
+  revision: c7f6f07c5ddca7a9e51241ed926c905feeaa2d83
   specs:
     travis-sso (0.0.1)
       multi_json
@@ -18,27 +18,27 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.5)
-      activesupport (= 5.1.5)
-    activerecord (5.1.5)
-      activemodel (= 5.1.5)
-      activesupport (= 5.1.5)
-      arel (~> 8.0)
-    activesupport (5.1.5)
+    activemodel (5.2.1.1)
+      activesupport (= 5.2.1.1)
+    activerecord (5.2.1.1)
+      activemodel (= 5.2.1.1)
+      activesupport (= 5.2.1.1)
+      arel (>= 9.0)
+    activesupport (5.2.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    arel (8.0.0)
-    backports (3.11.1)
-    concurrent-ruby (1.0.5)
-    faraday (0.14.0)
+    arel (9.0.0)
+    backports (3.11.4)
+    concurrent-ruby (1.1.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     hashr (2.0.1)
-    i18n (0.9.5)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -48,35 +48,37 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
-    pg (1.0.0)
-    public_suffix (3.0.2)
-    puma (3.11.3)
+    pg (1.1.3)
+    public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.6)
-    rack-protection (2.0.1)
+    rack-protection (2.0.4)
       rack
     rack-ssl (1.4.1)
       rack
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    redis (4.0.1)
+    redis (4.0.3)
     rerun (0.13.0)
       listen (~> 3.0)
-    rotp (3.3.1)
+    rotp (4.0.2)
+      addressable (~> 2.5)
     ruby_dep (1.5.0)
-    sentry-raven (2.7.2)
+    sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
-    sinatra (2.0.1)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.1)
-      backports (>= 2.0)
+    sinatra-contrib (2.0.4)
+      activesupport (>= 4.0.0)
+      backports (>= 2.8.2)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.1)
-      sinatra (= 2.0.1)
+      rack-protection (= 2.0.4)
+      sinatra (= 2.0.4)
       tilt (>= 1.3, < 3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -96,7 +98,7 @@ DEPENDENCIES
   redis
   rerun
   sentry-raven
-  sinatra
+  sinatra (>= 2.0.2)
   sinatra-contrib
   travis-config!
   travis-sso!
@@ -105,4 +107,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,11 +47,11 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     pg (1.0.0)
     public_suffix (3.0.2)
     puma (3.11.3)
-    rack (2.0.4)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     rack-ssl (1.4.1)


### PR DESCRIPTION
rack, sinatra, and activemodel:
https://nvd.nist.gov/vuln/detail/CVE-2018-16470
https://nvd.nist.gov/vuln/detail/CVE-2018-16471
https://nvd.nist.gov/vuln/detail/CVE-2018-11627

